### PR TITLE
Add ordering for IP proxying, requirements document and TCP fallback

### DIFF
--- a/proposed_charter.md
+++ b/proposed_charter.md
@@ -18,7 +18,7 @@ and configure flows for different services.
 
 The primary goal of this working group is to develop mechanisms that allow
 configuring and concurrently running multiple proxied stream- and datagram-based
-flows inside a HTTP connection. The group will specify HTTP and/or HTTP/3
+flows inside an HTTP connection. The group will specify HTTP and/or HTTP/3
 extensions to enable this functionality. The group will focus on a limited set
 of client-initiated services: (1) UDP CONNECT and (2) IP proxying.
 

--- a/proposed_charter.md
+++ b/proposed_charter.md
@@ -13,7 +13,7 @@ advantage of a unified congestion controller. An HTTP/3 datagram construct built
 on top of QUIC datagram frames would provide for unreliable data transmission
 and enable transporting UDP and other unreliable flows via a proxy. Moreover, it
 would not introduce potentially redundant or unnecessary recovery mechanisms.
-Lastly, HTTP/3 supports an established request/response semantic that can set up
+Lastly, HTTP supports an established request/response semantic that can set up
 and configure flows for different services.
 
 The primary goal of this working group is to develop mechanisms that allow
@@ -24,6 +24,8 @@ of client-initiated services: (1) UDP CONNECT and (2) IP proxying.
 
 The working group will also consider fallback to versions of HTTP that operate
 over TCP, as resilience to blocking of UDP or HTTP/3 is desired.
+
+Server-initiated services are out of scope.
 
 Multicast UDP and multicast IP support is out of scope. However, the group may
 specify extension points that would enable future work on multicast. Specifying

--- a/proposed_charter.md
+++ b/proposed_charter.md
@@ -23,8 +23,8 @@ extensions to enable this functionality. The group will focus on a limited set
 of client-initiated services: (1) UDP CONNECT and (2) IP proxying.
 
 The working group will first deliver a protcol solution for UDP CONNECT and a
-requirements document for IP proxying. Once complete, it will focus on a
-protocol solution for IP proxying.
+requirements document for IP proxying. Once both are complete, the working group
+will focus on a protocol solution for IP proxying.
 
 The working group will also consider fallback to versions of HTTP that operate
 over TCP, as resilience to blocking of UDP or HTTP/3 is desired.

--- a/proposed_charter.md
+++ b/proposed_charter.md
@@ -22,6 +22,9 @@ flows inside a HTTP connection. The group will specify HTTP and/or HTTP/3
 extensions to enable this functionality. The group will focus on a limited set
 of client-initiated services: (1) UDP CONNECT and (2) IP proxying.
 
+The working group will also consider fallback to versions of HTTP that operate
+over TCP, as resilience to blocking of UDP or HTTP/3 is desired.
+
 Multicast UDP and multicast IP support is out of scope. However, the group may
 specify extension points that would enable future work on multicast. Specifying
 proxy server discovery mechanisms is also out of scope, but the group may

--- a/proposed_charter.md
+++ b/proposed_charter.md
@@ -18,10 +18,9 @@ and configure flows for different services.
 
 The primary goal of this working group is to develop mechanisms that allow
 configuring and concurrently running multiple proxied stream- and datagram-based
-flows inside a HTTP/3 connection. The group will specify HTTP or HTTP/3
-extensions to enable this functionality within an HTTP/3 connection. The group
-will focus on a limited set of client-initiated services: (1) UDP CONNECT and
-(2) IP proxying.
+flows inside a HTTP connection. The group will specify HTTP and/or HTTP/3
+extensions to enable this functionality. The group will focus on a limited set
+of client-initiated services: (1) UDP CONNECT and (2) IP proxying.
 
 Multicast UDP and multicast IP support is out of scope. However, the group may
 specify extension points that would enable future work on multicast. Specifying

--- a/proposed_charter.md
+++ b/proposed_charter.md
@@ -22,6 +22,10 @@ flows inside a HTTP connection. The group will specify HTTP and/or HTTP/3
 extensions to enable this functionality. The group will focus on a limited set
 of client-initiated services: (1) UDP CONNECT and (2) IP proxying.
 
+The working group will first deliver a protcol solution for UDP CONNECT and a
+requirements document for IP proxying. Once complete, it will focus on a
+protocol solution for IP proxying.
+
 The working group will also consider fallback to versions of HTTP that operate
 over TCP, as resilience to blocking of UDP or HTTP/3 is desired.
 


### PR DESCRIPTION
Plus some other review comments. Separate commits as these are somewhat separate, but all touch the same text.